### PR TITLE
#35 nullable global id

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # eRecruiter API ChangeLog
 
 ##v1.14.0
-- Changed ``ApplicantParameter`` to allow ``GlobalId`` to be NULL
+- Changed ``ApplicantParameter`` to allow ``GlobalId`` to be a nullable long value for better support in external systems
 
 ##v1.13.0
 - New `company` synchronization for XML content (requires company permission for the api key) for the following endpoint

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # eRecruiter API ChangeLog
 
+##v1.14.0
+- Changed ``ApplicantParameter`` to allow ``GlobalId`` to be NULL
+
 ##v1.13.0
 - New `company` synchronization for XML content (requires company permission for the api key) for the following endpoint
   - `Api/Synchronize/Company` can receive the content of an company XML formated string and synchronizes the mandators companies

--- a/eRecruiter.Api/Parameters/Applicant/ApplicantParameter.cs
+++ b/eRecruiter.Api/Parameters/Applicant/ApplicantParameter.cs
@@ -48,7 +48,7 @@ namespace eRecruiter.Api.Parameters
         /// <summary>
         /// Global identifier for same appliant in different mandators.
         /// </summary>
-        public int GlobalId { get; set; }
+        public long? GlobalId { get; set; }
 
         /// <summary>
         /// Optional identifiener for third party applications.

--- a/eRecruiter.Api/Properties/AssemblyInfo.cs
+++ b/eRecruiter.Api/Properties/AssemblyInfo.cs
@@ -9,6 +9,6 @@
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("1.13.0.0")]
-[assembly: AssemblyFileVersion("1.13.0.0")]
-[assembly: AssemblyInformationalVersion("1.13.0")]
+[assembly: AssemblyVersion("1.14.0.0")]
+[assembly: AssemblyFileVersion("1.14.0.0")]
+[assembly: AssemblyInformationalVersion("1.14.0")]


### PR DESCRIPTION
Change the ``GlobalId`` field in the ``ApplicantParameter`` to allow ``null`` values and change the data type to ``long`` for better support in external systems.