### PR TITLE
[PDE-88] added property for privacy policy acceptance date

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # eRecruiter API ChangeLog
 
+## 1.28.0
+- New fields for `ApplicantParameter` to support information about the privacy policy (EU-DSVGO)
+	- `PolicyAcceptedAt` used to transfer/set the date for acceptance of the privacy policy.
+
 ## 1.27.1
 - Add documentation to custom fields to avoid further misunderstandings.
 	

--- a/eRecruiter.Api.Client/eRecruiter.Api.Client.nuspec
+++ b/eRecruiter.Api.Client/eRecruiter.Api.Client.nuspec
@@ -9,7 +9,7 @@
 		<description>$description$</description>
 		
 		<dependencies>
-			<dependency id="eRecruiter.Api" version="1.27.0" />
+			<dependency id="eRecruiter.Api" version="1.28.0" />
 		</dependencies>	
 	</metadata>
 </package>

--- a/eRecruiter.Api/Parameters/Applicant/ApplicantParameter.cs
+++ b/eRecruiter.Api/Parameters/Applicant/ApplicantParameter.cs
@@ -182,5 +182,10 @@ namespace eRecruiter.Api.Parameters
         /// Gets or sets the maximum distance to a job location desired by the applicant.
         /// </summary>
         public float? MaximumDistanceToJobLocation { get; set; }
+
+        /// <summary>
+        /// Get or set the date when the privacy policy has been accepted.
+        /// </summary>
+        public DateTime? PolicyAcceptedAt { get; set; }
     }
 }

--- a/eRecruiter.Api/Properties/AssemblyInfo.cs
+++ b/eRecruiter.Api/Properties/AssemblyInfo.cs
@@ -9,6 +9,6 @@
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("1.27.1.0")]
-[assembly: AssemblyFileVersion("1.27.1.0")]
-[assembly: AssemblyInformationalVersion("1.27.1")]
+[assembly: AssemblyVersion("1.28.0.0")]
+[assembly: AssemblyFileVersion("1.28.0.0")]
+[assembly: AssemblyInformationalVersion("1.28.0")]


### PR DESCRIPTION
Added a property to `ApplicantParameter` that allows to get/set the date of the privacy policy acceptance. This field is required for the implementation of features that provide support for the EUDSGVO.